### PR TITLE
feat: use ubuntu latest for instrumentation tests

### DIFF
--- a/.github/workflows/semantic_library_workflow.yml
+++ b/.github/workflows/semantic_library_workflow.yml
@@ -173,7 +173,7 @@ jobs:
     name: Instrumentation Tests
     if: inputs.run_instrumentation_tests == true
     needs: [ commit_lint, code_lint ]
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0


### PR DESCRIPTION
Open source projects now benefit from virtualization on the latest runners leading to faster instrumentation test execution.
[Test run on cache library.](https://github.com/krogerco/Cache-Android/actions/runs/8900409078/job/24441956247)