### PR TITLE
feat: remove wrapper validation job

### DIFF
--- a/.github/workflows/semantic_library_workflow.yml
+++ b/.github/workflows/semantic_library_workflow.yml
@@ -100,13 +100,6 @@ jobs:
           node_version: ${{ inputs.node_version }}
           commitlint_version: ${{ inputs.commitlint_version }}
 
-  wrapper_validation:
-    name: "Wrapper Validation"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v3
-
   code_lint:
     name: Code Lint
     needs: [ wrapper_validation ]


### PR DESCRIPTION
Wrapper validation is now performed automatically when using the setup-gradle action, so there's no need for our specific job any more.

See: https://github.com/gradle/actions/tree/main/wrapper-validation

> Starting with v4 the setup-gradle action will automatically [perform wrapper validation](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation) on each execution.
> 
> If you are using setup-gradle in your workflows, it is unlikely that you will need to use the wrapper-validation action.