### PR TITLE
fix: remove dependency on wrapper_validation for code lint

### DIFF
--- a/.github/workflows/semantic_library_workflow.yml
+++ b/.github/workflows/semantic_library_workflow.yml
@@ -102,7 +102,6 @@ jobs:
 
   code_lint:
     name: Code Lint
-    needs: [ wrapper_validation ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The wrapper_validation job was removed, but the code_lint job still depends on it. This removes it from the `needs` array.